### PR TITLE
Add error messages and style improvements

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -5,33 +5,33 @@
   <body>
     <style>
       .content {
-        margin: 10px 30px;
-        width: 300px;
+        margin: 8px 16px;
+        width: 480px;
+        height: 160px;
       }
       input, textarea {
         width: 100%;
         min-height: 30px;
         border-radius: 4px;
         border: 1px solid grey;
+        padding: 4px;
+      }
+      input, textarea, button {
+        margin-bottom: 16px;
       }
       textarea {
         height: 150px;
       }
-      .inputWrapper {
-        margin-bottom: 40px;
-      }
       button {
-        margin: 10px 0px;
         width: 100%;
         padding: 10px;
-        background-color: red;
+        background-color: #9011fe;
         color: white;
         font-size: 18px;
         border: none;
         border-radius: 5px;
       }
       #outputWrapper {
-        margin-top: 20px;
         opacity: 0.5;
         pointer-events: none;
       }
@@ -39,25 +39,23 @@
         opacity: 1;
         pointer-events: auto;
       }
+      #statusMessage {
+        margin-top: 8px;
+        margin-bottom: 8px;
+        font-size: 12px;
+      }
     </style>
 
     <div class="content">
       <div class="inputWrapper">
-        <h1>Resource name:</h1>
-        <input id="resourceName" placeholder="Gimme the name" />
-        <h1>Datadog JSON:</h1>
-        <textarea id="datadogJson" placeholder="Gimme the JSON"></textarea>
+        <input id="resourceName" placeholder="your_resource_name" />
+        <textarea id="datadogJson" placeholder="{&#10;  &quot;name&quot;: &quot;Some lovely monitor&quot;,&#10;  &quot;type&quot;: &quot;metric alert&quot;,&#10;  &quot;query&quot;: ...&#10;}"></textarea>
         <button id="convertButton">Convert & copy result</button>
-        <span id="onClickMessage"></span>
+        <p id="statusMessage"></p>
       </div>
-
-      <hr />
 
       <div id="outputWrapper">
-        <h1>Terraform Code:</h1>
-        <textarea id="result" placeholder="Paste your Datadog monitor JSON above to generate Terraform code..."></textarea>
       </div>
-    </div>
 
     <script type="module" src="popup.js"></script>
   </body>

--- a/popup.js
+++ b/popup.js
@@ -4,19 +4,40 @@ function onClick() {
   var resourceName = document.getElementById('resourceName').value;
   var datadogJson = document.getElementById('datadogJson').value;
 
-  var terraformAlarmCode = generateTerraformCode(resourceName, JSON.parse(datadogJson));
-  document.getElementById('result').innerHTML = terraformAlarmCode;
-
-  document.getElementById('outputWrapper').classList.add('active');
-  document.getElementById('onClickMessage').innerHTML = 'Copied to clipboard!';
-
-  copyResult();
+  try {
+    var terraformAlarmCode = generateTerraformCode(resourceName, JSON.parse(datadogJson));
+    addDomElementsForResult(terraformAlarmCode);
+    copyResultToClipboard();
+    updateStatusMessage('Copied to clipboard!', false);
+  } catch (e) {
+    updateStatusMessage(e, true);
+  }
 }
 
-function copyResult() {
+function addDomElementsForResult(terraformAlarmCode) {
+  var resultTextArea = document.createElement('textarea');
+  resultTextArea.id = 'result';
+  resultTextArea.innerHTML = terraformAlarmCode;
+
+  var outputWrapperDiv = document.getElementById('outputWrapper');
+  outputWrapperDiv.appendChild(resultTextArea);
+  outputWrapperDiv.classList.add('active');
+}
+
+function copyResultToClipboard() {
   var copyText = document.getElementById('result');
   copyText.select();
   document.execCommand('copy');
+}
+
+function updateStatusMessage(message, isError) {
+  var newMessageText = isError ? '❗️' + message : '🎉' + message;
+  var statusMessageElement = document.getElementById('statusMessage');
+  statusMessageElement.innerHTML = newMessageText;
+  document.getElementById('convertButton').style.marginBottom = '0';
+  if (isError) {
+    statusMessageElement.style.color = 'red';
+  }
 }
 
 document.getElementById('convertButton').addEventListener('click', onClick);


### PR DESCRIPTION
Take a look at the [Contributing Guidelines](../CONTRIBUTING.md) before submitting a PR. Thanks for your help, we appreciate it!

***

# Why?
When the code conversion failed it was hard to know why. Now the error messages are lifted into the UI for better usability. I guess this mostly fixes https://github.com/intercom/datadog-to-terraform/issues/7 (though the error messages themselves could be nicer)

While I was at it, I also improved the visual structure of the popup by removing clutter. 

# How?
- Hide the "results" area until the conversion has been attempted
- If the conversion fails, simply show the error message
- Otherwise, display the terraform code and copy it to the clipboard

# UI Changes
## Before
![image](https://user-images.githubusercontent.com/9434500/65162379-098d0400-da31-11e9-896c-28b511acc471.png)

## After
When first opened:
![image](https://user-images.githubusercontent.com/9434500/65162129-b6b34c80-da30-11e9-9d05-eac47d49cbc7.png)

When conversion is successful:
![image](https://user-images.githubusercontent.com/9434500/65162079-9d120500-da30-11e9-8ded-c3ded6ef6343.png)

With error:
![image](https://user-images.githubusercontent.com/9434500/65162050-8f5c7f80-da30-11e9-9bcd-522b648ae1f1.png)
