### PR TITLE
skipping id field

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -70,6 +70,8 @@ function convert(key, value) {
     result += assignmentString(key, value);
   } else if (key === "options") {
     result += convertOptions(value);
+  } else if (key == 'id') {
+    return result;
   } else {
     throw `Conversion for "${key}" not found`;
   }


### PR DESCRIPTION
Take a look at the [Contributing Guidelines](../CONTRIBUTING.md) before submitting a PR. Thanks for your help, we appreciate it!

***

# Why?
Towards https://github.com/intercom/datadog-to-terraform/issues/23

# How?
If you copy the JSON from datadog it contains an id key. 
Prior to this PR, the id key would raise an error as there is no expected conversion found, see [code](https://github.com/serenaf/datadog-to-terraform/blob/04d3cb26ffd1c39ecdf20d71013a5e36b3ff3cd8/generator.js#L76)

In this PR we skip the id and return early if the key is id

# UI Changes

## Before

![before](https://user-images.githubusercontent.com/1288131/79154746-05a74180-7dc8-11ea-8e6f-b7e79f18e041.png)

## After
![after](https://user-images.githubusercontent.com/1288131/79154763-0b9d2280-7dc8-11ea-9800-8c2e1751d2c4.png)
